### PR TITLE
fix: correct typo and parameter name

### DIFF
--- a/text2image.py
+++ b/text2image.py
@@ -1,6 +1,6 @@
 from tensorflow import keras
 from stable_diffusion_tensorflow.stable_diffusion import Text2Image
-import argparase
+import argparse
 from PIL import Image
 
 parser = argparse.ArgumentParser()
@@ -63,7 +63,7 @@ if args.mp:
     print("Using mixed precision")
     keras.mixed_precision.set_global_policy("mixed_floats16")
 
-generator = Text2Image(img_height=args.H, img_width=args.W, jit_compose=False)
+generator = Text2Image(img_height=args.H, img_width=args.W, jit_compile=False)
 img = generator.generate(
     args.prompt,
     num_steps=args.steps,


### PR DESCRIPTION
Hello, thanks for the awesome work!
I noticed the main script of the project contains a couple of typos - probably due to a refactor - which don't allow running the image generation. 

**CHANGELOG:**

* correct typo in misspelled argparse import
* correct parameter name - `jit_compile` (was `jit_compose`)